### PR TITLE
Full width sidebar and hamburger menu when on mobile version

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@
 
   <div id="top" class="sg-header" role="banner">
     <div class="sg-container">
-      <button type="button" class="sg-nav-toggle">Menu</button>
+      <img class="sg-nav-toggle" width="36" height="36" src="images/icon/icon-20-o-hamburger.svg" alt="hamburger menu"/>
     </div>
   </div><!--/.sg-header-->
 

--- a/scss/_sidebar.scss
+++ b/scss/_sidebar.scss
@@ -11,11 +11,11 @@
 
 .js.nav-is-active .sg-sidebar {
   height: 100%;
+  width: 100%;
   opacity: 1;
   overflow-y: scroll;
   position: fixed;
   top: 0%;
-  width: 200px;
   z-index: 2;
 }
 
@@ -46,17 +46,13 @@
 }
 
 .sg-nav-toggle {
-  background-color: #000;
+  border: 2px $grey-50 solid;
   border-radius: 5px;
-  border: 1px solid #7C7C7C;
-  color: #fff;
+  background-color: white;
+  cursor: pointer;
   float: right;
-  font-size: 16px;
-  font-size: 1rem;
-  padding: 5px 8px;
+  padding: 8px;
   /* For older browsers */
-  padding: 0.3125rem 0.5rem;
-  text-decoration: none;
   -webkit-transition: all .15s ease-in;
   -moz-transition: all .15s ease-in;
   -ms-transition: all .15s ease-in;


### PR DESCRIPTION
## What this does
  - Made sidebar have full width when on mobile
  - Switched out menu button to hamburger icon
 
## Follow up tasks
  - Fix animation on when the sidebar is shown
 
### Before
<img width="381" alt="Screen Shot 2019-03-13 at 11 03 23 AM" src="https://user-images.githubusercontent.com/3793714/54303212-bc127480-457f-11e9-9f23-23bd20922405.png">
<img width="396" alt="Screen Shot 2019-03-13 at 11 03 28 AM" src="https://user-images.githubusercontent.com/3793714/54303261-d2b8cb80-457f-11e9-9b0b-88b839be3869.png">

 
### After
<img width="392" alt="Screen Shot 2019-03-13 at 11 02 22 AM" src="https://user-images.githubusercontent.com/3793714/54303194-b0bf4900-457f-11e9-89b0-50362d4d0f69.png">
<img width="391" alt="Screen Shot 2019-03-13 at 11 02 35 AM" src="https://user-images.githubusercontent.com/3793714/54303232-c765a000-457f-11e9-8875-6dde57816489.png">